### PR TITLE
docs: fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,11 +313,11 @@ You can also give this repository a star to show more people and they can use th
 
 ## :star2: Star History
 
-<a href="https://star-history.com/#sanidhyy/duolingo-clone&Timeline">
+<a href="https://star-history.dera.page/#sanidhyy/duolingo-clone&Timeline">
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=sanidhyy/duolingo-clone&type=Timeline&theme=dark" />
-  <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=sanidhyy/duolingo-clone&type=Timeline" />
-  <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=sanidhyy/duolingo-clone&type=Timeline" />
+  <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=sanidhyy/duolingo-clone&type=Timeline&theme=dark" />
+  <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=sanidhyy/duolingo-clone&type=Timeline" />
+  <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=sanidhyy/duolingo-clone&type=Timeline" />
 </picture>
 </a>
 


### PR DESCRIPTION
The star history chart in the README is currently broken and needs to be fixed, as the project's star history is no longer visible. This pull request restores it by updating the chart source so it renders correctly again.