### PR TITLE
fix: disable vercel image optimization to save resources

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+  images: { unoptimized: true },
   devIndicators: false,
   headers: async () => [
     {


### PR DESCRIPTION
## Summary
- Set `images.unoptimized` to `true` in Next.js config so `next/image` serves original sources instead of Vercel Image Optimization to save resources.